### PR TITLE
Insert var declaration before the first path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export default function ({ types: t }) {
             let declar = t.variableDeclaration("var", [
               t.variableDeclarator(uid, newString)
             ]);
-            let childOfProgramPath = path.findParent((path) => {
+            let childOfProgramPath = cachedValue.firstPath.findParent((path) => {
               return path.parentPath.isProgram();
             });
             childOfProgramPath.insertBefore(declar);


### PR DESCRIPTION
I ran into a case where the declaration of string literal vars was placed after first use (the `each` call below). This change addresses the issue

```js
// Add some isType methods: isFunction, isString, isNumber, isDate, isRegExp.
const is = [];
each(['Function', 'String', 'Number', 'Date', 'RegExp'], function (name) {
    is[name] = function (obj) {
        return toString.call(obj) == '[object ' + name + ']';
    };
});

// Optimize `isFunction` if appropriate.
if (typeof (/./) !== 'function') {
    is['Function'] = function (obj) {
        return typeof obj === 'function';
    };
}

const isDate = is['Date'];
const isRegExp = is['RegExp'];

export const isFunction = is['Function'];
export const isNumber = is['Number'];
export const isString = is['String'];
```

resulted in this, rather than having the vars declared before `each` is invoked:
```js
// Add some isType methods: isFunction, isString, isNumber, isDate, isRegExp.
const is = [];
each([_, _1, _2, _3, _4], function (name) {
    is[name] = function (obj) {
        return toString.call(obj) == '[object ' + name + ']';
    };
});
var _ = 'Function'
var _1...
```